### PR TITLE
import globals.css to layout.tsx

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,4 +1,5 @@
 import { ClerkProvider } from '@clerk/nextjs'
+import './globals.css';
 
 export default function RootLayout({
   children,


### PR DESCRIPTION
The existing `layout.tsx` file lacks the importation of `globals.css`, resulting in the website being displayed without any styling.

This pull request addresses this issue by importing the essential update required for the template to be properly styled.