### PR TITLE
feat: Added cssLayerName to Tailwind 4 support

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1,3 +1,4 @@
+@layer theme, base, clerk, components, utilities;
 @import 'tailwindcss';
 
 :root {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -24,7 +24,9 @@ export default function RootLayout({
   children: React.ReactNode
 }>) {
   return (
-    <ClerkProvider>
+    <ClerkProvider appearance={{
+      cssLayerName: 'clerk'
+    }}>
       <html lang="en">
         <body className={`${geistSans.variable} ${geistMono.variable} antialiased`}>
           <header className="flex justify-end items-center p-4 gap-4 h-16">


### PR DESCRIPTION
See [Tailwind CSS v4 Support Changelog](https://clerk.com/changelog/2025-06-17-css-layer-name) for context.

Since our Quickstart installs Next with Tailwind 4 and this repo (and the Pages example repo in the future probably) includes Tailwind 4, we should consider adding `cssLayerName` to the repo and/or Quickstart.